### PR TITLE
Correct directory diffing test and algorithm

### DIFF
--- a/pkg/test/files_test.go
+++ b/pkg/test/files_test.go
@@ -51,13 +51,13 @@ func TestExpectMatchingDirectories(t *testing.T) {
 func TestDiffDirectories(t *testing.T) {
 	g := NewWithT(t)
 
-	// Finds files in expected from a/ but not in actual b/.
-	aonly, _, _ := DiffDirectories("testdata/diff/a", "testdata/diff/b")
-	g.Expect(aonly).To(Equal([]string{"/only", "/only/here.yaml", "/onlyhere.yaml"}))
-
 	// Finds files in actual a/ that weren't expected from b/.
-	bonly, _, _ := DiffDirectories("testdata/diff/a", "testdata/diff/b") // change in order
-	g.Expect(bonly).To(Equal([]string{"/only", "/only/here.yaml", "/onlyhere.yaml"}))
+	actualonly, _, _ := DiffDirectories("testdata/diff/a", "testdata/diff/b")
+	g.Expect(actualonly).To(Equal([]string{"/only", "/onlyhere.yaml"}))
+
+	// Finds files in expected from a/ but not in actual b/.
+	_, expectedonly, _ := DiffDirectories("testdata/diff/b", "testdata/diff/a") // NB change in order
+	g.Expect(expectedonly).To(Equal([]string{"/only", "/onlyhere.yaml"}))
 
 	// Finds files that are different in a and b.
 	_, _, diffs := DiffDirectories("testdata/diff/a", "testdata/diff/b")


### PR DESCRIPTION
Two steps:

1. TestDiffDirectories did not check if the expected only return value
was correct; the intention was there to do so (judging by the
comment "change in order"), but my eye for detail failed me.

2. Reversing the directory comparison in the test revealed bugs in the
comparison code -- in general, it should skip any directory that is
not a directory in the comparator.

To make this easier, the code now keeps track of the expected files it
saw. That means the check for whether an actual file has an expected
counterpart only has two cases, yes or no (rather that trying to
account for whether it's a directory and so on). If a directory was
skipped while scanning the expected files, it won't be in the actual
files anyway.
